### PR TITLE
feat: add workflow states retrieval for teams

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -151,13 +151,13 @@ The following tools are recommended for future implementation to enhance the cap
 
 ### Workflow Management
 
-| Tool Name                      | Description                             | Priority | Status     |
-| ------------------------------ | --------------------------------------- | -------- | ---------- |
-| `linear_getWorkflowStates`     | Get all workflow states                 | Medium   | 📝 Planned |
-| `linear_createWorkflowState`   | Create a new workflow state             | Low      | 📝 Planned |
-| `linear_updateWorkflowState`   | Update a workflow state                 | Low      | 📝 Planned |
-| `linear_getTeamStates`         | Get workflow states for a specific team | Medium   | 📝 Planned |
-| `linear_reorderWorkflowStates` | Change the order of workflow states     | Low      | 📝 Planned |
+| Tool Name                      | Description                             | Priority | Status         |
+| ------------------------------ | --------------------------------------- | -------- | -------------- |
+| `linear_getWorkflowStates`     | Get all workflow states                 | Medium   | ✅ Implemented |
+| `linear_createWorkflowState`   | Create a new workflow state             | Low      | 📝 Planned     |
+| `linear_updateWorkflowState`   | Update a workflow state                 | Low      | 📝 Planned     |
+| `linear_getTeamStates`         | Get workflow states for a specific team | Medium   | 📝 Planned     |
+| `linear_reorderWorkflowStates` | Change the order of workflow states     | Low      | 📝 Planned     |
 
 ### Team Management
 

--- a/src/services/linear-service.ts
+++ b/src/services/linear-service.ts
@@ -1094,4 +1094,38 @@ export class LinearService {
       throw error;
     }
   }
+
+  /**
+   * Get workflow states for a team
+   * @param teamId ID of the team to get workflow states for
+   * @param includeArchived Whether to include archived states (default: false)
+   * @returns Array of workflow states with their details
+   */
+  async getWorkflowStates(teamId: string, includeArchived = false) {
+    try {
+      // Use GraphQL to query workflow states for the team
+      const response = await this.client.workflowStates({
+        filter: {
+          team: { id: { eq: teamId } },
+          ...(includeArchived ? {} : { archivedAt: { null: true } })
+        }
+      });
+      
+      if (!response.nodes || response.nodes.length === 0) {
+        return [];
+      }
+      
+      // Map the response to match our output schema
+      return response.nodes.map(state => ({
+        id: state.id,
+        name: state.name,
+        type: state.type,
+        position: state.position,
+        color: state.color,
+        description: state.description || ""
+      }));
+    } catch (error) {
+      throw new Error(`Failed to get workflow states: ${error.message}`);
+    }
+  }
 } 

--- a/src/tools/definitions/index.ts
+++ b/src/tools/definitions/index.ts
@@ -29,7 +29,7 @@ import {
   addIssueToProjectToolDefinition,
   getProjectIssuesToolDefinition
 } from "./project-tools.js";
-import { getTeamsToolDefinition } from "./team-tools.js";
+import { getTeamsToolDefinition, getWorkflowStatesToolDefinition } from "./team-tools.js";
 import {
   getViewerToolDefinition,
   getOrganizationToolDefinition,
@@ -53,6 +53,7 @@ export const allToolDefinitions: MCPToolDefinition[] = [
   
   // Team tools
   getTeamsToolDefinition,
+  getWorkflowStatesToolDefinition,
   
   // Project tools
   getProjectsToolDefinition,
@@ -106,6 +107,7 @@ export {
   getProjectsToolDefinition,
   createProjectToolDefinition,
   getTeamsToolDefinition,
+  getWorkflowStatesToolDefinition,
   getViewerToolDefinition,
   getOrganizationToolDefinition,
   getUsersToolDefinition,

--- a/src/tools/definitions/team-tools.ts
+++ b/src/tools/definitions/team-tools.ts
@@ -33,3 +33,39 @@ export const getTeamsToolDefinition: MCPToolDefinition = {
     }
   }
 }; 
+
+/**
+ * Tool definition for getting workflow states for a team
+ */
+export const getWorkflowStatesToolDefinition: MCPToolDefinition = {
+  name: "linear_getWorkflowStates",
+  description: "Get workflow states for a team",
+  input_schema: {
+    type: "object",
+    properties: {
+      teamId: {
+        type: "string",
+        description: "ID of the team to get workflow states for",
+      },
+      includeArchived: {
+        type: "boolean",
+        description: "Whether to include archived states (default: false)",
+      },
+    },
+    required: ["teamId"],
+  },
+  output_schema: {
+    type: "array",
+    items: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        name: { type: "string" },
+        type: { type: "string" },
+        position: { type: "number" },
+        color: { type: "string" },
+        description: { type: "string" }
+      }
+    }
+  }
+}; 

--- a/src/tools/handlers/index.ts
+++ b/src/tools/handlers/index.ts
@@ -29,7 +29,7 @@ import {
   handleAddIssueToProject,
   handleGetProjectIssues
 } from "./project-handlers.js";
-import { handleGetTeams } from "./team-handlers.js";
+import { handleGetTeams, handleGetWorkflowStates } from "./team-handlers.js";
 import {
   handleGetViewer,
   handleGetOrganization,
@@ -58,6 +58,7 @@ export function registerToolHandlers(linearService: LinearService) {
 
     // Team tools
     linear_getTeams: handleGetTeams(linearService),
+    linear_getWorkflowStates: handleGetWorkflowStates(linearService),
 
     // Project tools
     linear_getProjects: handleGetProjects(linearService),
@@ -112,6 +113,7 @@ export {
   handleGetProjects,
   handleCreateProject,
   handleGetTeams,
+  handleGetWorkflowStates,
   handleGetViewer,
   handleGetOrganization,
   handleGetUsers,

--- a/src/tools/handlers/team-handlers.ts
+++ b/src/tools/handlers/team-handlers.ts
@@ -1,5 +1,6 @@
 import { LinearService } from "../../services/linear-service.js";
 import { logError } from "../../utils/config.js";
+import { isGetWorkflowStatesArgs } from "../type-guards.js";
 
 /**
  * Handler for getting teams
@@ -10,6 +11,27 @@ export function handleGetTeams(linearService: LinearService) {
       return await linearService.getTeams();
     } catch (error) {
       logError("Error getting teams", error);
+      throw error;
+    }
+  };
+} 
+
+/**
+ * Handler for getting workflow states for a team
+ */
+export function handleGetWorkflowStates(linearService: LinearService) {
+  return async (args: unknown) => {
+    try {
+      if (!isGetWorkflowStatesArgs(args)) {
+        throw new Error("Invalid arguments for getWorkflowStates");
+      }
+      
+      return await linearService.getWorkflowStates(
+        args.teamId, 
+        args.includeArchived || false
+      );
+    } catch (error) {
+      logError("Error getting workflow states", error);
       throw error;
     }
   };

--- a/src/tools/type-guards.ts
+++ b/src/tools/type-guards.ts
@@ -416,4 +416,30 @@ export function isAddIssueToCycleArgs(args: unknown): args is {
     "cycleId" in args &&
     typeof (args as { cycleId: string }).cycleId === "string"
   );
+}
+
+/**
+ * Type guard for linear_getWorkflowStates tool arguments
+ */
+export function isGetWorkflowStatesArgs(args: unknown): args is {
+  teamId: string;
+  includeArchived?: boolean;
+} {
+  if (
+    typeof args !== "object" ||
+    args === null ||
+    !("teamId" in args) ||
+    typeof (args as { teamId: string }).teamId !== "string"
+  ) {
+    return false;
+  }
+
+  if (
+    "includeArchived" in args &&
+    typeof (args as { includeArchived: boolean }).includeArchived !== "boolean"
+  ) {
+    return false;
+  }
+
+  return true;
 } 


### PR DESCRIPTION
Implemented a new feature to fetch workflow states for a specific team.

- Added `getWorkflowStates` method in the service to handle fetching.
- Created tool definition for `linear_getWorkflowStates`.
- Implemented handler to process requests for workflow states.
- Added type guard to validate input arguments.
- Updated documentation to reflect the new tool's status as implemented.

Now you can easily get all relevant workflow states, including an option to include archived ones!
